### PR TITLE
feat!: remove match 'm' alias

### DIFF
--- a/src/public/match.ts
+++ b/src/public/match.ts
@@ -166,7 +166,6 @@ function match<TIn, TOut, TInExt extends TIn = TIn>(
 
 export {
     match,
-    match as m,
     /** @since 1.0.0 */
     match as arm,
     /** @since 1.0.0 */


### PR DESCRIPTION
BREAKING CHANGE: dropping 'm' alias as it is unnecessarily terse and doesn't contribute to the readability of your code. use `arm` or `when` instead.